### PR TITLE
Implement setting for custom preamble location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ node_modules
 package-lock.json
 
 # build
+data.json
 main.js
 *.js.map


### PR DESCRIPTION
This issue addresses https://github.com/xldenis/obsidian-latex/issues/11#issue-910785565, specifically the below feature request:

> I do find it slightly untidy to have my preamble in the root of the vault though, and I am wondering if you would implement a setting that can be used to specify the path to the preamble file?

Unfortunately, this requires Obsidian to be reloaded and I couldn't figure out how to reload MathJax, which is required to implement the following request in the same thread:

> I wonder if it would be possible to "choose the closest preamble" - i.e. have folder-level preamble settings.
